### PR TITLE
Implemented DAL testing for all DAL classes but Lodging

### DIFF
--- a/code/CapstoneBackend/DAL/TransportationDAL.cs
+++ b/code/CapstoneBackend/DAL/TransportationDAL.cs
@@ -54,10 +54,17 @@ namespace CapstoneBackend.DAL
             cmd.Parameters.Add("@endDate", MySqlDbType.DateTime).Value = endDate;
             cmd.Parameters.Add("@notes", MySqlDbType.VarChar).Value = notes;
 
-            var transportationId = Convert.ToInt32(cmd.ExecuteScalar());
-
-            _connection.Close();
-            return transportationId;
+            try
+            {
+                var transportationId = Convert.ToInt32(cmd.ExecuteScalar());
+                _connection.Close();
+                return transportationId;
+            }
+            catch
+            {
+                _connection.Close();
+                throw;
+            }
         }
 
         /// <summary>
@@ -115,7 +122,18 @@ namespace CapstoneBackend.DAL
 
             cmd.Parameters.Add("@transportationId", MySqlDbType.Int32).Value = transportationId;
 
-            return cmd.ExecuteNonQuery() == 1;
+            try
+            {
+                var result = cmd.ExecuteNonQuery();
+                _connection.Close();
+                return result == 1;
+            }
+            catch
+            {
+                _connection.Close();
+                throw;
+            }
+            
         }
 
         /// <summary>

--- a/code/CapstoneBackend/DAL/WaypointDAL.cs
+++ b/code/CapstoneBackend/DAL/WaypointDAL.cs
@@ -54,10 +54,17 @@ namespace CapstoneBackend.DAL
             cmd.Parameters.Add("@endDate", MySqlDbType.DateTime).Value = endDate;
             cmd.Parameters.Add("@notes", MySqlDbType.VarChar).Value = notes;
 
-            var waypointId = Convert.ToInt32(cmd.ExecuteScalar());
-
-            _connection.Close();
-            return waypointId;
+            try
+            {
+                var waypointId = Convert.ToInt32(cmd.ExecuteScalar());
+                _connection.Close();
+                return waypointId;
+            }
+            catch
+            {
+                _connection.Close();
+                throw;
+            }
         }
 
         /// <summary>
@@ -73,7 +80,7 @@ namespace CapstoneBackend.DAL
             cmd.CommandType = CommandType.StoredProcedure;
             IList<Waypoint> waypointsInTrip = new List<Waypoint>();
 
-            cmd.Parameters.Add("@tripId", MySqlDbType.UInt32).Value = tripId;
+            cmd.Parameters.Add("@tripId", MySqlDbType.Int32).Value = tripId;
 
 
             using var reader = cmd.ExecuteReader();
@@ -152,9 +159,19 @@ namespace CapstoneBackend.DAL
             using MySqlCommand cmd = new(procedure, _connection);
             cmd.CommandType = CommandType.StoredProcedure;
 
-            cmd.Parameters.Add("@waypointId", MySqlDbType.UInt32).Value = waypointId;
+            cmd.Parameters.Add("@waypointId", MySqlDbType.Int32).Value = waypointId;
 
-            return cmd.ExecuteNonQuery() == 1;
+            try
+            {
+                int result = cmd.ExecuteNonQuery();
+                _connection.Close();
+                return result == 1;
+            }
+            catch
+            {
+                _connection.Close();
+                throw;
+            }
         }
 
         /// <summary>

--- a/code/CapstoneDatabase/uspGetWaypointsByTripId.sql
+++ b/code/CapstoneDatabase/uspGetWaypointsByTripId.sql
@@ -3,10 +3,10 @@ DROP PROCEDURE IF EXISTS uspGetWaypointsByTripId;
 DELIMITER $
 
 CREATE PROCEDURE uspGetWaypointsByTripId(
-	tripId INT UNSIGNED
+	tripId INT
 )
 BEGIN
-        SELECT waypointId, location, startDate, endDate
+        SELECT waypointId, location, startDate, endDate, notes
         FROM waypoint
         WHERE waypoint.tripId = tripId;
 END$

--- a/code/CapstoneDatabase/uspRemoveTransportation.sql
+++ b/code/CapstoneDatabase/uspRemoveTransportation.sql
@@ -6,7 +6,7 @@ CREATE PROCEDURE uspRemoveTransportation(
 	transportationId INT
 )
 BEGIN
-	DELETE FROM transportation WHERE transportationId = transportationId;
+	DELETE FROM transportation WHERE transportation.transportationId = transportationId;
 END$
 
 DELIMITER ;

--- a/code/CapstoneDatabase/uspRemoveWaypoint.sql
+++ b/code/CapstoneDatabase/uspRemoveWaypoint.sql
@@ -3,10 +3,10 @@ DROP PROCEDURE IF EXISTS uspRemoveWaypoint;
 DELIMITER $
 
 CREATE PROCEDURE uspRemoveWaypoint(
-	waypointId INT UNSIGNED
+	waypointId INT
 )
 BEGIN
-	DELETE FROM waypoint WHERE waypointId = waypointId;
+	DELETE FROM waypoint WHERE waypoint.waypointId = waypointId;
 END$
 
 DELIMITER ;

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestCreateTransportation.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestCreateTransportation.cs
@@ -1,0 +1,59 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
+{
+    [TestClass]
+    public class TestCreateTransportation
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testTransportationId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithIvalidTripId_Fails()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            Assert.ThrowsException<MySqlException>(() => testDAL.CreateTransportation(-1, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes"));
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidInput_Succeeds()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            int? resultID = testDAL.CreateTransportation(testTripId, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes");
+            testTransportationId = (int) resultID;
+
+            Assert.IsTrue(resultID is not null);
+            Assert.IsTrue(resultID is int);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeTransportation = $"delete from transportation where transportationId = {testTransportationId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand transportationCmd = new MySqlCommand(removeTransportation, _connection);
+            transportationCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationById.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationById.cs
@@ -1,0 +1,61 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestGetTransportationById
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testTransportationId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidWaypointId_ReturnsNull()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            Transportation? result = testDAL.GetTransportationById(-1);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidWaypointId_ReturnsWaypoint()
+        {
+            TransportationDal testDAL = new(_connection);
+            testTransportationId = testDAL.CreateTransportation(1, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes");
+
+            Transportation? result = testDAL.GetTransportationById(1);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is Transportation);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testTransportationId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationById.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationById.cs
@@ -21,7 +21,7 @@ namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithInvalidWaypointId_ReturnsNull()
+        public void CallProcedure_WithInvalidTransportationId_ReturnsNull()
         {
             TransportationDal testDAL = new(_connection);
 
@@ -31,7 +31,7 @@ namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithValidWaypointId_ReturnsWaypoint()
+        public void CallProcedure_WithValidTransportationId_ReturnsTransportation()
         {
             TransportationDal testDAL = new(_connection);
             testTransportationId = testDAL.CreateTransportation(1, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes");

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationOnDate.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationOnDate.cs
@@ -1,0 +1,62 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+
+namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
+{
+    [TestClass]
+    public class TestGetTransportationOnDate
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testTransportationId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now.AddDays(7));
+            testTransportationId = new TransportationDal(_connection).CreateTransportation(testTripId, "TestMethod", DateTime.Now.AddDays(2), DateTime.Now.AddDays(7), null);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithNoWaypointsOnDate_ReturnsEmpty()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            IList<Transportation> result = testDAL.GetTransportationOnDate(testTripId, DateTime.Now);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithWaypointDate_ReturnsList()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            IList<Transportation> result = testDAL.GetTransportationOnDate(testTripId, DateTime.Now.AddDays(3));
+
+            Assert.AreEqual(1, result.Count);
+        }
+
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeTransportation = $"delete from transportation where transportationId = {testTransportationId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand transportationCmd = new MySqlCommand(removeTransportation, _connection);
+            transportationCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationOnDate.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestGetTransportationOnDate.cs
@@ -23,7 +23,7 @@ namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithNoWaypointsOnDate_ReturnsEmpty()
+        public void CallProcedure_WithNoTransportationOnDate_ReturnsEmpty()
         {
             TransportationDal testDAL = new(_connection);
 
@@ -33,7 +33,7 @@ namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithWaypointDate_ReturnsList()
+        public void CallProcedure_WithTransportationOnDate_ReturnsList()
         {
             TransportationDal testDAL = new(_connection);
 

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestRemoveTransportation.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestRemoveTransportation.cs
@@ -21,7 +21,7 @@ namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithInvalidWaypointId_ReturnsFalse()
+        public void CallProcedure_WithInvalidTransportationId_ReturnsFalse()
         {
             TransportationDal testDAL = new(_connection);
 
@@ -31,7 +31,7 @@ namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithValidWaypointId_ReturnsTrue()
+        public void CallProcedure_WithValidTransportationId_ReturnsTrue()
         {
             TransportationDal testDAL = new(_connection);
             testTransportationId = testDAL.CreateTransportation(testTripId, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes");

--- a/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestRemoveTransportation.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTransportationDAL/TestRemoveTransportation.cs
@@ -1,0 +1,60 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestTransportationDAL
+{
+    [TestClass]
+    public class TestRemoveTransportation
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testTransportationId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidWaypointId_ReturnsFalse()
+        {
+            TransportationDal testDAL = new(_connection);
+
+            bool result = testDAL.RemoveTransportation(-1);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidWaypointId_ReturnsTrue()
+        {
+            TransportationDal testDAL = new(_connection);
+            testTransportationId = testDAL.CreateTransportation(testTripId, "TestMethod", DateTime.Now, DateTime.Now, "Some Notes");
+
+            bool result = testDAL.RemoveTransportation(testTransportationId);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeTransportation = $"delete from transportation where transportationId = {testTransportationId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand transportationCmd = new MySqlCommand(removeTransportation, _connection);
+            transportationCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestCreateTrip.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestCreateTrip.cs
@@ -19,7 +19,7 @@ namespace CapstoneTest.BackendTests.DAL.TestTripDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithIvalidUserId_Fails()
+        public void CallProcedure_WithInvalidUserId_Fails()
         {
             TripDal testDAL = new(_connection);
 

--- a/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestCreateTrip.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestCreateTrip.cs
@@ -1,0 +1,52 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestTripDAL
+{
+    [TestClass]
+    public class TestCreateTrip
+    {
+        private MySqlConnection _connection;
+        private int testTripId = -1;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithIvalidUserId_Fails()
+        {
+            TripDal testDAL = new(_connection);
+
+            Assert.ThrowsException<MySqlException>(() => testDAL.CreateTrip(-1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now));
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidInput_Succeeds()
+        {
+            TripDal testDAL = new(_connection);
+
+            int? resultID = testDAL.CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+            testTripId = (int) resultID;
+
+            Assert.IsTrue(resultID is not null);
+            Assert.IsTrue(resultID is int);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string query = $"delete from trip where tripId = {testTripId};";
+
+            using MySqlCommand cmd = new MySqlCommand(query, _connection);
+            cmd.ExecuteNonQuery();
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestGetTripByTripId.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestGetTripByTripId.cs
@@ -1,0 +1,54 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestTripDAL
+{
+    [TestClass]
+    public class TestGetTripByTripId
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidTripId_ReturnsNull()
+        {
+            TripDal testDAL = new(_connection);
+
+            Trip? result = testDAL.GetTripByTripId(-1);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidTripId_Succeeds()
+        {
+            TripDal testDAL = new(_connection);
+            testTripId = testDAL.CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+
+            Trip? result = testDAL.GetTripByTripId(1);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is Trip);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string query = $"delete from trip where tripId = {testTripId};";
+
+            using MySqlCommand cmd = new MySqlCommand(query, _connection);
+            cmd.ExecuteNonQuery();
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestGetTripsByUserId.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestTripDAL/TestGetTripsByUserId.cs
@@ -1,0 +1,54 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+
+namespace CapstoneTest.BackendTests.DAL.TestTripDAL
+{
+    [TestClass]
+    public class TestGetTripsByUserId
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidUserId_ReturnsEmpty()
+        {
+            TripDal testDAL = new(_connection);
+
+            IList<Trip> resultList = testDAL.GetTripsByUserId(-1);
+
+            Assert.AreEqual(0, resultList.Count);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidUserId_Succeeds()
+        {
+            TripDal testDAL = new(_connection);
+
+            IList<Trip> resultList = testDAL.GetTripsByUserId(1);
+
+            Assert.IsTrue(resultList.Count > 0);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string query = $"delete from trip where tripId = {testTripId};";
+
+            using MySqlCommand cmd = new MySqlCommand(query, _connection);
+            cmd.ExecuteNonQuery();
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestCreateWaypoint.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestCreateWaypoint.cs
@@ -1,0 +1,59 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestCreateWaypoint
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testWaypointId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithIvalidTripId_Fails()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            Assert.ThrowsException<MySqlException>(() => testDAL.CreateWaypoint(-1, "TestLocation", DateTime.Now, DateTime.Now, "Some Notes"));
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidInput_Succeeds()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            int? resultID = testDAL.CreateWaypoint(testTripId, "TestLocation", DateTime.Now, DateTime.Now, "Some Notes");
+            testWaypointId = (int) resultID;
+
+            Assert.IsTrue(resultID is not null);
+            Assert.IsTrue(resultID is int);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testWaypointId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointById.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointById.cs
@@ -1,0 +1,61 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestGetWaypointById
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testWaypointId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidWaypointId_ReturnsNull()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            Waypoint? result = testDAL.GetWaypointById(-1);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidWaypointId_ReturnsWaypoint()
+        {
+            WaypointDal testDAL = new(_connection);
+            testWaypointId = testDAL.CreateWaypoint(1, "TestLocation", DateTime.Now, DateTime.Now, "Some Notes");
+
+            Waypoint? result = testDAL.GetWaypointById(1);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is Waypoint);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testWaypointId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsByTripId.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsByTripId.cs
@@ -1,0 +1,61 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestGetWaypointsByTripId
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testWaypointId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now.AddDays(7));
+            testWaypointId = new WaypointDal(_connection).CreateWaypoint(testTripId, "TestLocation", DateTime.Now.AddDays(2), DateTime.Now.AddDays(7), "SomeNotes");
+        }
+
+        [TestMethod]
+        public void CallProcedure_InvalidTripId_ReturnsEmpty()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            IList<Waypoint> result = testDAL.GetWaypointsByTripId(-1);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void CallProcedure_ValidTripWithWaypoint_ReturnsList()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            IList<Waypoint> result = testDAL.GetWaypointsByTripId(testTripId);
+
+            Assert.AreEqual(1, result.Count);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testWaypointId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsOnDate.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsOnDate.cs
@@ -1,0 +1,62 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestGetWaypointsOnDate
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testWaypointId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now.AddDays(7));
+            testWaypointId = new WaypointDal(_connection).CreateWaypoint(testTripId, "TestLocation", DateTime.Now.AddDays(2), DateTime.Now.AddDays(7), null);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithNoWaypointsOnDate_ReturnsEmpty()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            IList<Waypoint> result = testDAL.GetWaypointsOnDate(testTripId, DateTime.Now);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithWaypointDate_ReturnsList()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            IList<Waypoint> result = testDAL.GetWaypointsOnDate(testTripId, DateTime.Now.AddDays(3));
+
+            Assert.AreEqual(1, result.Count);
+        }
+
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testWaypointId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsOnDate.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestGetWaypointsOnDate.cs
@@ -33,7 +33,7 @@ namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
         }
 
         [TestMethod]
-        public void CallProcedure_WithWaypointDate_ReturnsList()
+        public void CallProcedure_WithWaypointOnDate_ReturnsList()
         {
             WaypointDal testDAL = new(_connection);
 

--- a/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestRemoveWaypoint.cs
+++ b/code/CapstoneTest/BackendTests/DAL/TestWaypointDAL/TestRemoveWaypoint.cs
@@ -1,0 +1,60 @@
+﻿using CapstoneBackend.DAL;
+using CapstoneBackend.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace CapstoneTest.BackendTests.DAL.TestWaypointDAL
+{
+    [TestClass]
+    public class TestRemoveWaypoint
+    {
+        private MySqlConnection _connection;
+        private int testTripId;
+        private int testWaypointId;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _connection = new MySqlConnection(Connection.ConnectionString);
+            testTripId = new TripDal(_connection).CreateTrip(1, "TestTrip", "Some Notes", DateTime.Now, DateTime.Now);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithInvalidWaypointId_ReturnsFalse()
+        {
+            WaypointDal testDAL = new(_connection);
+
+            bool result = testDAL.RemoveWaypoint(-1);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CallProcedure_WithValidWaypointId_ReturnsTrue()
+        {
+            WaypointDal testDAL = new(_connection);
+            testWaypointId = testDAL.CreateWaypoint(1, "TestLocation", DateTime.Now, DateTime.Now, "Some Notes");
+
+            bool result = testDAL.RemoveWaypoint(testWaypointId);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _connection.Open();
+            string removeTrip = $"delete from trip where tripId = {testTripId};";
+            string removeWaypoint = $"delete from waypoint where waypointId = {testWaypointId};";
+
+            using MySqlCommand tripCmd = new MySqlCommand(removeTrip, _connection);
+            tripCmd.ExecuteNonQuery();
+
+            using MySqlCommand waypointCmd = new MySqlCommand(removeWaypoint, _connection);
+            waypointCmd.ExecuteNonQuery();
+
+            this._connection.Close();
+        }
+    }
+}


### PR DESCRIPTION
Apologies for the super commit, I reset my branch multiple times from main while trying to correctly setup and teardown these tests in isolation without effecting anything else.

Fixed some Dal::Create or Dal::Remove methods that were not closing the connection.
Fixed SQL bug where entire tables would be cleared on removal

Changed some unsigned integers to signed integers for testability. We have a mix of unsigned and signed ints in our sql files, so we could discuss what to settle on. The signed integers make it easier to test. Ex: Testing behavior when passed an invalid ID. With signed you can just test with -1, with signed it makes things more complicated