### PR TITLE
Integrated Google Maps Places Autocomplete into the Web Client

### DIFF
--- a/code/CapstoneWeb/Pages/CreateLodging.cshtml
+++ b/code/CapstoneWeb/Pages/CreateLodging.cshtml
@@ -12,8 +12,10 @@
     <p class="error @isErrorVisible">@Model.ErrorMessage</p>
 
     <form method="post">
-        <label for="method">Location* </label>
-        <input id="method" asp-for="Location" required />
+        <label for="location">Location* </label>
+        <input id="location" placeholder="Enter a place:" type="text" asp-for="Location" required />
+
+        <div id="map"></div>
 
         <label for="notes">Notes</label>
         <textarea id="notes" asp-for="Notes"></textarea>
@@ -43,3 +45,10 @@
     </form>
 
 </div>
+
+@section Scripts {
+    <script src="~/js/googleMaps.js"></script>
+    <script async
+            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDmYx_C23N0TLFO234gBQBBL3EMZ9HYIG4&libraries=places&callback=initAutocomplete">
+    </script>
+}

--- a/code/CapstoneWeb/Pages/CreateWaypoint.cshtml
+++ b/code/CapstoneWeb/Pages/CreateWaypoint.cshtml
@@ -13,7 +13,9 @@
 
     <form method="post">
         <label for="location">Location* </label>
-        <input id="location" asp-for="Location" required />
+        <input id="location" placeholder="Enter a place:" type="text" asp-for="Location" required />
+
+        <div id="map"></div>
 
         <label for="notes">Notes</label>
         <textarea id="notes" asp-for="Notes"></textarea>
@@ -42,3 +44,10 @@
     </form>
 
 </div>
+
+@section Scripts {
+    <script src="~/js/googleMaps.js"></script>
+    <script async
+            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDmYx_C23N0TLFO234gBQBBL3EMZ9HYIG4&libraries=places&callback=initAutocomplete">
+    </script>
+}

--- a/code/CapstoneWeb/wwwroot/js/googleMaps.js
+++ b/code/CapstoneWeb/wwwroot/js/googleMaps.js
@@ -1,6 +1,9 @@
 ﻿
 let autocomplete;
 
+/**
+ * Initializes the autocomplete on an input element with  the ID: 'location'
+ * */
 function initAutocomplete() {
     autocomplete = new google.maps.places.Autocomplete(
         document.getElementById('location'),
@@ -8,4 +11,19 @@ function initAutocomplete() {
             types: ['establishment'],
             fields: ['place_id', 'geometry', 'name']
         });
+
+    autocomplete.addListener('place_changed', onPlaceChanged);
+}
+
+/**
+ * Callback for when an autocomplete option is clicked/changed
+ * */
+function onPlaceChanged() {
+    var place = autocomplete.getPlace();
+
+    if (!place.geometry) {
+        document.getElementById('location').placeholder = 'Enter a place:';
+    } else {
+        document.getElementById('map').innerHTML = place.name;
+    }
 }

--- a/code/CapstoneWeb/wwwroot/js/googleMaps.js
+++ b/code/CapstoneWeb/wwwroot/js/googleMaps.js
@@ -1,0 +1,11 @@
+﻿
+let autocomplete;
+
+function initAutocomplete() {
+    autocomplete = new google.maps.places.Autocomplete(
+        document.getElementById('location'),
+        {
+            types: ['establishment'],
+            fields: ['place_id', 'geometry', 'name']
+        });
+}


### PR DESCRIPTION
Autocomplete occurs when typing into the location fields in Create Waypoint and Create Lodging pages.
There is a callback that is called on the event an autocomplete option is clicked.
This can be used to load maps in the near future.

There is not yet any real restriction on creating waypoints or lodging if the entry is not a valid place in the google places API. I'll work on that next.